### PR TITLE
yubikey_mass_enroll: default to random_prefix 6 for MODE_YUBICO

### DIFF
--- a/privacyideautils/yubikey.py
+++ b/privacyideautils/yubikey.py
@@ -119,8 +119,6 @@ def enrollYubikey(digits=6, APPEND_CR=True, debug=False, unlock_key=None, access
             raise YubiError("privacyIDEA only supports the OATH challenge Response mode at the moment!")
         else:
             Cfg.mode_yubikey_otp(uid, 'h:' + key)
-        if len_fixed_string == 0:
-            len_fixed_string = 6
 
     elif mode == MODE_OATH:
         key = binascii.hexlify(os.urandom(20))

--- a/privacyideautils/yubikey.py
+++ b/privacyideautils/yubikey.py
@@ -119,6 +119,8 @@ def enrollYubikey(digits=6, APPEND_CR=True, debug=False, unlock_key=None, access
             raise YubiError("privacyIDEA only supports the OATH challenge Response mode at the moment!")
         else:
             Cfg.mode_yubikey_otp(uid, 'h:' + key)
+        if len_fixed_string == 0:
+            len_fixed_string = 6
 
     elif mode == MODE_OATH:
         key = binascii.hexlify(os.urandom(20))
@@ -145,10 +147,13 @@ def enrollYubikey(digits=6, APPEND_CR=True, debug=False, unlock_key=None, access
     # Do the fixed string:
     if prefix_serial:
         Cfg.fixed_string(serial)
-    if fixed_string:
+    elif fixed_string:
         Cfg.fixed_string(fixed_string)
     elif len_fixed_string:
-        fs = os.urandom(len_fixed_string)
+        if mode == MODE_YUBICO:
+            fs = binascii.unhexlify('ff') + os.urandom(len_fixed_string - 1)
+        else:
+            fs = os.urandom(len_fixed_string)
         Cfg.fixed_string(fs)
 
     # set CR behind OTP value

--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -988,7 +988,7 @@ def create_arguments():
                           "of length",
                           metavar="NUMBER",
                           type=int,
-                          default=6)
+                          default=0)
     p_ykmass.add_argument("--yubiprefixserial",
                           help="Use the serial number of "
                           "the yubikey as prefix.", action="store_true")

--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -988,7 +988,7 @@ def create_arguments():
                           "of length",
                           metavar="NUMBER",
                           type=int,
-                          default=0)
+                          default=6)
     p_ykmass.add_argument("--yubiprefixserial",
                           help="Use the serial number of "
                           "the yubikey as prefix.", action="store_true")


### PR DESCRIPTION
The OTP generated by a yubikey in AES mode must be 44 characters for yubico cloud.  The
first 12 characters are the public ID of the token, the rest will be
the OTP.  When initializing with the yubikey personalization tool you
can create an optional private identity that is included as an input
parameter in the OTP generation algorithm.  It is not used for
identification of the token.

For a short documentation how to initialize a token see
https://www.yubico.com/wp-content/uploads/2013/07/YubiKey_YubiCloud_Configuration.pdf
or the video at
https://www.yubico.com/products/services-software/personalization-tools/yubikey-otp/ .


According to http://forum.yubico.com/viewtopic.php?f=16&t=2110 the
first two characters of the modhex prefix are "cc" for factory
programmed tokens and "vv" should be used for customer programmed
tokens for the Yubico cloud service.  The personalization tool will
create the prefix automatically.  To reach goal 2 we should generate a
"vv" prefix, but might want to enable users to set a custom prefix
when mass enrolling tokens.
