### PR TITLE
yubikey: default prefix length in MODE_YUBICO is 6, otherwise 0

### DIFF
--- a/privacyideautils/yubikey.py
+++ b/privacyideautils/yubikey.py
@@ -78,7 +78,7 @@ def create_static_password(key_hex):
 def enrollYubikey(digits=6, APPEND_CR=True, debug=False, unlock_key=None, access_key=None, slot=1,
                   mode=MODE_OATH,
                   fixed_string=None,
-                  len_fixed_string=0,
+                  len_fixed_string=-1,
                   prefix_serial=False,
                   challenge_response=False):
     '''
@@ -114,6 +114,13 @@ def enrollYubikey(digits=6, APPEND_CR=True, debug=False, unlock_key=None, access
         Cfg.unlock_key(unlock_key)
     if access_key:
         Cfg.access_key(access_key)
+
+    # default fixed string length is 0, but 6 for MODE_YUBICO
+    if len_fixed_string == -1:
+        if mode == MODE_YUBICO:
+            len_fixed_string = 6
+        else:
+            len_fixed_string = 0
 
     if mode == MODE_YUBICO:
         key = binascii.hexlify(os.urandom(16))

--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -146,6 +146,9 @@ def yubi_mass_enroll(lotpc,
             elif yubi_prefix:
                 yubi_otplen = 32 + (len(yubi_prefix) * 2)
             elif yubi_prefix_random:
+                # default prefix length for MODE_YUBICO is 6
+                if yubi_prefix_random == -1:
+                    yubi_prefix_random = 6
                 yubi_otplen = 32 + (yubi_prefix_random * 2)
             # According to http://www.openauthentication.org/oath-id/prefixes/
             # The OMP of Yubico is UB
@@ -996,7 +999,7 @@ def create_arguments():
                           "of length",
                           metavar="NUMBER",
                           type=int,
-                          default=0)
+                          default=-1)
     p_ykmass.add_argument("--yubiprefixserial",
                           help="Use the serial number of "
                           "the yubikey as prefix.", action="store_true")


### PR DESCRIPTION
In scripts/privacyidea we use a default of -1 for --yubiprefixrandom
for MODE_YUBICO.  That way we can distinguish between no length given
on the command line, where we'll use a length of 6 and a parameter 0,
which means no prefix, so we can be backwards compatible.

Other modes for yubikeys are unchanged.

In enrollYubikey we handle len_fixed_string == -1 for MODE_YUBICO and
use 6 as a default length.  In yubi_mass_enroll we calculate the otplen,
so we'll need to handle -1 too.  Otherwise validation would fail.
After this change we can enroll UBAM tokens (MODE_YUBICO) and use them
as well as UBOM token (OATH).

After all the patches we can now use
privacyidea yubikey_mass_enroll --yubimode YUBICO
without additional options and get a token that works directly with /validate/check 
as well as /ttype/yubikey.
