### PR TITLE
Fix the OTPLEN in yubico mode

### DIFF
--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -104,7 +104,6 @@ def yubi_mass_enroll(lotpc,
     :param yubi_new_access_key: new access key
     """
     yp = YubikeyPlug()
-    print proc_params
     description = proc_params.description
     filename = proc_params.filename
     print filename
@@ -150,10 +149,8 @@ def yubi_mass_enroll(lotpc,
 
         elif yubi_mode == MODE_YUBICO:
             yubi_otplen = 32
-            if yubi_prefix_serial:
-                yubi_otplen = 32 + len(serial) * 2
-            elif yubi_prefix:
-                yubi_otplen = 32 + (len(yubi_prefix) * 2)
+            if prefix:
+                yubi_otplen = 32 + len(prefix) * 2
             elif yubi_prefix_random:
                 # default prefix length for MODE_YUBICO is 6
                 if yubi_prefix_random is None:
@@ -492,8 +489,6 @@ def yubikey_mass_enroll(args, client):
 
 def nitrokey_mass_enroll(args, client):
     NK = NitroKey()
-    print args
-    print client
 
     if args.nitromode == "TOTP":
         raise Exception("At the moment we only support HOTP.")

--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -150,7 +150,7 @@ def yubi_mass_enroll(lotpc,
         elif yubi_mode == MODE_YUBICO:
             yubi_otplen = 32
             if prefix:
-                yubi_otplen = 32 + len(prefix) * 2
+                yubi_otplen = 32 + len(prefix)
             elif yubi_prefix_random:
                 # default prefix length for MODE_YUBICO is 6
                 if yubi_prefix_random is None:


### PR DESCRIPTION
When the token is initialized with a fixed prefix,
we also add this very prefix to the length of the OTPPIN.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyideaadm/pull/32%23discussion_r175077039%22%2C%20%22https%3A//github.com/privacyidea/privacyideaadm/pull/32%23discussion_r175082333%22%2C%20%22https%3A//github.com/privacyidea/privacyideaadm/pull/32%23discussion_r175082509%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%207e0f70584c648de36b89f7ddbdf8a13ffe166ff9%20scripts/privacyidea%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyideaadm/pull/32%23discussion_r175077039%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20%27prefix%27%20returned%20by%20%27enrollYubikey%27%20is%20already%20Hex-coded%20and%20thus%20we%20don%27t%20need%20to%20duplicate%20the%20prefix%20length.%22%2C%20%22created_at%22%3A%20%222018-03-16T12%3A40%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22will%20fix%20this.%22%2C%20%22created_at%22%3A%20%222018-03-16T13%3A03%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-03-16T13%3A04%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20scripts/privacyidea%3AL149-157%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 7e0f70584c648de36b89f7ddbdf8a13ffe166ff9 scripts/privacyidea 17'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyideaadm/pull/32#discussion_r175077039'>File: scripts/privacyidea:L149-157</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> the 'prefix' returned by 'enrollYubikey' is already Hex-coded and thus we don't need to duplicate the prefix length.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> will fix this.


<a href='https://www.codereviewhub.com/privacyidea/privacyideaadm/pull/32?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyideaadm/pull/32?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyideaadm/pull/32'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>