### PR TITLE
Add parameter to use PI-Authorization header

### DIFF
--- a/privacyideautils/clientutils.py
+++ b/privacyideautils/clientutils.py
@@ -136,9 +136,9 @@ class privacyideaclient(object):
             if result.get("status") is True:
                 self.auth_token = result.get("value", {}).get("token")
                 if self.pi_authorization:
-                    self.headers = {"Authorization": self.auth_token}
-                else:
                     self.headers = {"PI-Authorization": self.auth_token}
+                else:
+                    self.headers = {"Authorization": self.auth_token}
         else:
             raise Exception("Invalid Credentials: %s" % r.status_code)
 

--- a/privacyideautils/clientutils.py
+++ b/privacyideautils/clientutils.py
@@ -83,15 +83,17 @@ class privacyideaclient(object):
     """
 
     def __init__(self, username, password, baseuri="http://localhost:5000",
-                 no_ssl_check=False):
+                 no_ssl_check=False, pi_authorization=False):
         """
         :param baseuri: The base of the server like http://localhost:5000
         :type baseuri: basestring
         """
         self.auth_token = None
+        self.headers = None
         self.baseuri = baseuri
         self.log = logging.getLogger('privacyideaclient')
         self.verify_ssl = not no_ssl_check
+        self.pi_authorization = pi_authorization
         if not self.verify_ssl:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         # Do the first server communication and retrieve the auth token
@@ -133,26 +135,30 @@ class privacyideaclient(object):
             result = res.get("result")
             if result.get("status") is True:
                 self.auth_token = result.get("value", {}).get("token")
+                if self.pi_authorization:
+                    self.headers = {"Authorization": self.auth_token}
+                else:
+                    self.headers = {"PI-Authorization": self.auth_token}
         else:
             raise Exception("Invalid Credentials: %s" % r.status_code)
 
     def get(self, uripath, param=None):
         r = requests.get("%s%s" % (self.baseuri, uripath),
-                         headers={"Authorization": self.auth_token},
+                         headers=self.headers,
                          params=param,
                          verify=self.verify_ssl)
         return self._send_response(r)
 
     def post(self, uripath, param=None):
         r = requests.post("%s%s" % (self.baseuri, uripath),
-                          headers={"Authorization": self.auth_token},
+                          headers=self.headers,
                           data=param,
                           verify=self.verify_ssl)
         return self._send_response(r)
 
     def delete(self, uripath):
         r = requests.delete("%s%s" % (self.baseuri, uripath),
-                            headers={"Authorization": self.auth_token},
+                            headers=self.headers,
                             verify=self.verify_ssl)
         return self._send_response(r)
 

--- a/scripts/privacyidea
+++ b/scripts/privacyidea
@@ -99,8 +99,11 @@ def print_version(ctx, param, value):
               help='The password of the user')
 @click.option('-n', '--nosslcheck',
               help='Do not check the SSL certificate', is_flag=True)
+@click.option('--pi-authorization',
+              help='Use the PI-Authorization header instead of Authorization header.',
+              is_flag=True)
 @click.pass_context
-def cli(ctx, url, admin, password, nosslcheck):
+def cli(ctx, url, admin, password, nosslcheck, pi_authorization):
     """
     Manage your tokens on the privacyIDEA server
 
@@ -111,7 +114,8 @@ def cli(ctx, url, admin, password, nosslcheck):
       $ privacyidea -U https://yourserver -a user token init
 
     """
-    client = privacyideaclient(admin, password, url, no_ssl_check=nosslcheck)
+    client = privacyideaclient(admin, password, url,
+                               no_ssl_check=nosslcheck, pi_authorization=pi_authorization)
     ctx.obj["pi_client"] = client
 
 


### PR DESCRIPTION
A command line parameter can be used to use
the PI-Authorization header instead of the Authorization header.

This way we keep up the backward compatibility and allow more
flexibility in the future.

Closes #49