### PR TITLE
Fix packaging for modern pip/setuptools

### DIFF
--- a/privacyideautils/commands/token.py
+++ b/privacyideautils/commands/token.py
@@ -352,13 +352,19 @@ def registration(ctx, realm, dump, mail_host, mail_from, mail_subject,
                    "only programmable with this new access key. "
                    "You can reset the access key by setting the "
                    "new access key to '000000000000'.")
+@click.option("--count",
+            help="Number of YubiKeys to initialize before exiting. "
+                "0 means unlimited.",
+            type=int,
+            default=0)
 def yubikey_mass_enroll(ctx, yubiprefix, yubiprefixrandom, yubiprefixserial,
-                        yubimode, filename, yubislot, yubicr, description, access, newaccess, realm):
+                    yubimode, filename, yubislot, yubicr, description, access, newaccess, realm, count):
     """
     Initialize a bunch of yubikeys
     """
     client = ctx.obj["pi_client"]
     yp = YubikeyPlug()
+    processed = 0
     while True:
         print("\nPlease insert the next yubikey.", end=' ')
         sys.stdout.flush()
@@ -432,6 +438,10 @@ def yubikey_mass_enroll(ctx, yubiprefix, yubiprefixrandom, yubiprefixserial,
             resp = client.inittoken(submit_param)
             print(resp.status)
             showresult(resp.data)
+
+        processed += 1
+        if count > 0 and processed >= count:
+            break
 
 
 @token.command()

--- a/privacyideautils/yubikey.py
+++ b/privacyideautils/yubikey.py
@@ -65,6 +65,21 @@ def to_bytes(s):
     return s
 
 
+def normalize_yubikey_access_key(key):
+    """Return access key as bytes with required b'h:' prefix."""
+    if key is None:
+        return None
+
+    key_b = to_bytes(key).strip()
+    if not key_b:
+        return None
+
+    if key_b.startswith(b"h:"):
+        return key_b
+
+    return b"h:" + key_b
+
+
 def modhex_encode(s):
     s = to_bytes(s)
     return binascii.hexlify(s).translate(t_map)
@@ -143,13 +158,14 @@ def enrollYubikey(digits=6, APPEND_CR=True, debug=False, access_key=None,
 
     # handle access_key and new_access_key
     if access_key:
-        access_key = access_key if access_key[1:] == "h:" else "h:"+access_key
-        Cfg.unlock_key(access_key)
+        access_key = normalize_yubikey_access_key(access_key)
+        if access_key:
+            Cfg.unlock_key(access_key)
     if new_access_key:
         # set new accesskey
-        new_access_key = new_access_key if new_access_key[1:] == "h:" else \
-            "h:" + new_access_key
-        Cfg.access_key(new_access_key)
+        new_access_key = normalize_yubikey_access_key(new_access_key)
+        if new_access_key:
+            Cfg.access_key(new_access_key)
 
     # default fixed string length is 0, but 6 for MODE_YUBICO
     if len_fixed_string is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ release = 1
 group = Productivity/Networking/Security
 vendor = privacyidea.org
 packager = cornelius@privacyidea.org
-Provides = privacyideaadm
+provides = privacyideaadm

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from setuptools import setup
-from setuptools.command.install import install
 import os
 import sys
 
@@ -11,15 +10,6 @@ release = '3.0'
 
 # Taken from kennethreitz/requests/setup.py
 package_directory = os.path.realpath(os.path.dirname(__file__))
-
-
-class InstallWithDoc(install):
-    def run(self):
-        self.run_command('build_sphinx')
-        install.run(self)
-
-
-cmdclass = {'install': InstallWithDoc}
 
 
 def get_file_contents(file_path):
@@ -41,8 +31,6 @@ setup(name=name,
       url='http://www.privacyidea.org',
       packages=['privacyideautils',
                 'privacyideautils.commands'],
-      setup_requires=['sphinx <= 1.8.5;python_version<"3.0"',
-                      'sphinx >= 2.0;python_version>="3.0"'],
       install_requires=[
           "cffi",
           "click",
@@ -52,16 +40,6 @@ setup(name=name,
           "requests",
           "six"
       ],
-      cmdclass=cmdclass,
-      command_options={
-        'build_sphinx': {
-            'project': ('setup.py', name),
-            'version': ('setup.py', version),
-            'source_dir': ('setup.py', 'doc'),
-            'build_dir': ('setup.py', os.path.join('doc', '_build')),
-            'builder': ('setup.py', 'man')
-        }
-      },
       scripts=['scripts/privacyidea',
                'scripts/privacyidea-luks-assign',
                'scripts/privacyidea-authorizedkeys',
@@ -69,7 +47,6 @@ setup(name=name,
                'scripts/privacyidea-get-offline-otp',
                'scripts/privacyidea-validate',
                'scripts/privacyidea-enroll-yubikey-piv'],
-      data_files=[('share/man/man1', ["doc/_build/man/privacyidea.1"])],
       license='AGPLv3',
       long_description=get_file_contents('DESCRIPTION')
       )


### PR DESCRIPTION
- remove forced build_sphinx during install
- remove fragile manpage data_files reference
- drop setup_requires sphinx hooks
- normalize setup.cfg provides key casing